### PR TITLE
Messages should not be final in order to support easier extensibility.

### DIFF
--- a/microraft/src/main/java/io/microraft/model/impl/groupop/DefaultUpdateRaftGroupMembersOpOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/groupop/DefaultUpdateRaftGroupMembersOpOrBuilder.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultUpdateRaftGroupMembersOpOrBuilder
+public class DefaultUpdateRaftGroupMembersOpOrBuilder
         implements UpdateRaftGroupMembersOp, UpdateRaftGroupMembersOpBuilder {
 
     private Collection<RaftEndpoint> members;

--- a/microraft/src/main/java/io/microraft/model/impl/log/DefaultLogEntryOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/log/DefaultLogEntryOrBuilder.java
@@ -26,7 +26,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultLogEntryOrBuilder
+public class DefaultLogEntryOrBuilder
         extends AbstractLogEntry
         implements LogEntry, LogEntryBuilder {
 

--- a/microraft/src/main/java/io/microraft/model/impl/log/DefaultSnapshotEntry.java
+++ b/microraft/src/main/java/io/microraft/model/impl/log/DefaultSnapshotEntry.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultSnapshotEntry
+public class DefaultSnapshotEntry
         extends AbstractLogEntry
         implements SnapshotEntry {
 

--- a/microraft/src/main/java/io/microraft/model/impl/message/DefaultAppendEntriesFailureResponseOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/message/DefaultAppendEntriesFailureResponseOrBuilder.java
@@ -26,7 +26,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultAppendEntriesFailureResponseOrBuilder
+public class DefaultAppendEntriesFailureResponseOrBuilder
         implements AppendEntriesFailureResponse, AppendEntriesFailureResponse.AppendEntriesFailureResponseBuilder {
 
     private Object groupId;

--- a/microraft/src/main/java/io/microraft/model/impl/message/DefaultAppendEntriesRequestOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/message/DefaultAppendEntriesRequestOrBuilder.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultAppendEntriesRequestOrBuilder
+public class DefaultAppendEntriesRequestOrBuilder
         implements AppendEntriesRequest, AppendEntriesRequestBuilder {
 
     private Object groupId;

--- a/microraft/src/main/java/io/microraft/model/impl/message/DefaultAppendEntriesSuccessResponseOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/message/DefaultAppendEntriesSuccessResponseOrBuilder.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultAppendEntriesSuccessResponseOrBuilder
+public class DefaultAppendEntriesSuccessResponseOrBuilder
         implements AppendEntriesSuccessResponse, AppendEntriesSuccessResponseBuilder {
 
     private Object groupId;

--- a/microraft/src/main/java/io/microraft/model/impl/message/DefaultInstallSnapshotRequestOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/message/DefaultInstallSnapshotRequestOrBuilder.java
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultInstallSnapshotRequestOrBuilder
+public class DefaultInstallSnapshotRequestOrBuilder
         implements InstallSnapshotRequest, InstallSnapshotRequestBuilder {
 
     private Object groupId;

--- a/microraft/src/main/java/io/microraft/model/impl/message/DefaultInstallSnapshotResponseOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/message/DefaultInstallSnapshotResponseOrBuilder.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultInstallSnapshotResponseOrBuilder
+public class DefaultInstallSnapshotResponseOrBuilder
         implements InstallSnapshotResponse, InstallSnapshotResponseBuilder {
 
     private Object groupId;

--- a/microraft/src/main/java/io/microraft/model/impl/message/DefaultPreVoteRequestOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/message/DefaultPreVoteRequestOrBuilder.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultPreVoteRequestOrBuilder
+public class DefaultPreVoteRequestOrBuilder
         implements PreVoteRequest, PreVoteRequestBuilder {
 
     private Object groupId;

--- a/microraft/src/main/java/io/microraft/model/impl/message/DefaultPreVoteResponseOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/message/DefaultPreVoteResponseOrBuilder.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultPreVoteResponseOrBuilder
+public class DefaultPreVoteResponseOrBuilder
         implements PreVoteResponse, PreVoteResponseBuilder {
 
     private Object groupId;

--- a/microraft/src/main/java/io/microraft/model/impl/message/DefaultTriggerLeaderElectionRequestOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/message/DefaultTriggerLeaderElectionRequestOrBuilder.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultTriggerLeaderElectionRequestOrBuilder
+public class DefaultTriggerLeaderElectionRequestOrBuilder
         implements TriggerLeaderElectionRequest, TriggerLeaderElectionRequestBuilder {
 
     private Object groupId;

--- a/microraft/src/main/java/io/microraft/model/impl/message/DefaultVoteRequestOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/message/DefaultVoteRequestOrBuilder.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultVoteRequestOrBuilder
+public class DefaultVoteRequestOrBuilder
         implements VoteRequest, VoteRequestBuilder {
 
     private Object groupId;

--- a/microraft/src/main/java/io/microraft/model/impl/message/DefaultVoteResponseOrBuilder.java
+++ b/microraft/src/main/java/io/microraft/model/impl/message/DefaultVoteResponseOrBuilder.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author metanet
  */
-public final class DefaultVoteResponseOrBuilder
+public class DefaultVoteResponseOrBuilder
         implements VoteResponse, VoteResponseBuilder {
 
     private Object groupId;


### PR DESCRIPTION
Adding parameters to already existing RAFT messages is going to be easier once the default implementations are not final.