### PR TITLE
SQLite implementation of the log

### DIFF
--- a/microraft-store-sqlite/pom.xml
+++ b/microraft-store-sqlite/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <root.dir>${project.parent.basedir}</root.dir>
-	    <jooq.version>3.17.5</jooq.version>
+	    <jooq.version>3.16.11</jooq.version>
 	    <sqlite.version>3.40.0.0</sqlite.version>
         <jackson.version>2.14.1</jackson.version>
     </properties>

--- a/microraft-store-sqlite/pom.xml
+++ b/microraft-store-sqlite/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.microraft</groupId>
+        <artifactId>microraft-root</artifactId>
+        <version>0.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>MicroRaft SQLite store</name>
+    <artifactId>microraft-store-sqlite</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <root.dir>${project.parent.basedir}</root.dir>
+	    <jooq.version>3.17.5</jooq.version>
+	    <sqlite.version>3.40.0.0</sqlite.version>
+        <jackson.version>2.14.1</jackson.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.microraft</groupId>
+            <artifactId>microraft</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq</artifactId>
+            <version>${jooq.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>${sqlite.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.microraft</groupId>
+            <artifactId>microraft</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/microraft-store-sqlite/src/main/java/io/microraft/store/sqlite/RaftSqliteStore.java
+++ b/microraft-store-sqlite/src/main/java/io/microraft/store/sqlite/RaftSqliteStore.java
@@ -1,0 +1,346 @@
+package io.microraft.store.sqlite;
+
+import io.microraft.RaftEndpoint;
+import io.microraft.lifecycle.RaftNodeLifecycleAware;
+import io.microraft.model.RaftModelFactory;
+import io.microraft.model.log.LogEntry;
+import io.microraft.model.log.RaftGroupMembersView;
+import io.microraft.model.log.SnapshotChunk;
+import io.microraft.model.log.SnapshotEntry;
+import io.microraft.persistence.RaftStore;
+import io.microraft.persistence.RestoredRaftState;
+
+import java.io.File;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.jooq.CloseableDSLContext;
+import org.jooq.Converter;
+import org.jooq.Field;
+import org.jooq.Name;
+import org.jooq.Record;
+import org.jooq.Record1;
+import org.jooq.Select;
+import org.jooq.Table;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.sqlite.SQLiteConfig;
+import org.sqlite.SQLiteConfig.JournalMode;
+import org.sqlite.SQLiteConfig.LockingMode;
+import org.sqlite.SQLiteConfig.Pragma;
+
+/**
+ * An implementation of a RaftStore which uses SQLite for persistence. A user of this class is advised to construct
+ * this class, and then use {@link RaftSqliteStore#getRestoredRaftState()} to acquire any previously persisted state.
+ * <p>
+ * At time of writing, this store prioritizes:
+ * <ul>
+ *     <li>
+ *         Being reasonably low overhead on individual writes. It should not be a major source of
+ *         overhead when replicating messages.
+ *     </li>
+ *     <li>
+ *         Being as straightforward as possible with all other operations.
+ *     </li>
+ * </ul>
+ * There are three tables which exist in this store.
+ * <ol>
+ *     <li>logEntries stores the log entries</li>
+ *     <li>snapshots and snapshotChunks store which snapshots exist and pointers to their chunks</li>
+ *     <li>kv stores the remaining metadata in a single-row, one-column-per-value 'key-value store'.</li>
+ * </ol>
+ */
+public final class RaftSqliteStore implements RaftStore, RaftNodeLifecycleAware {
+    private static final Table<Record> KV = DSL.table("kv");
+
+    private static final Field<String> KEY = DSL.field("key", SQLDataType.VARCHAR);
+    private static final String PK = "pk";
+    private static final Field<Boolean> LOCAL_ENDPOINT_VOTING = DSL.field("localEndpointVoting", SQLDataType.BOOLEAN);
+    private static final Field<Integer> TERM = DSL.field("term", SQLDataType.INTEGER);
+    private static final Table<Record> LOG_ENTRIES = DSL.table("logEntries");
+    private static final Field<Long> INDEX = DSL.field("logIndex", SQLDataType.BIGINT);
+    private static final Table<Record> SNAPSHOT_CHUNKS = DSL.table("snapshotChunks");
+    private static final Field<Integer> CHUNK_INDEX = DSL.field("chunkIndex", SQLDataType.INTEGER);
+    private static final Table<Record> SNAPSHOTS = DSL.table("snapshots");
+    private static final Field<Integer> CHUNK_COUNT = DSL.field("chunkCount", SQLDataType.INTEGER);
+    private static final Name COUNT = DSL.name("count");
+
+    private final Field<RaftGroupMembersView> initialGroupMembersField;
+    private final Field<RaftEndpoint> localEndpointField;
+    private final Field<RaftEndpoint> votedForField;
+    private final Field<LogEntry> logEntryField;
+    private final Field<SnapshotChunk> chunkField;
+    private final CloseableDSLContext dsl;
+    private final RaftModelFactory raftModelFactory;
+    private boolean tryToCleanUpOldSnapshots = false;
+
+    public RaftSqliteStore(
+            CloseableDSLContext dsl, StoreModelSerializer modelSerializer, RaftModelFactory raftModelFactory) {
+        this.dsl = dsl;
+        this.raftModelFactory = raftModelFactory;
+        initialGroupMembersField = DSL.field(
+                "initialGroupMembers",
+                SQLDataType.BINARY.asConvertedDataType(new JooqConverterAdapter<>(
+                        modelSerializer.raftGroupMembersViewSerializer(), RaftGroupMembersView.class)));
+        logEntryField = DSL.field(
+                "logEntry",
+                SQLDataType.BINARY.asConvertedDataType(
+                        new JooqConverterAdapter<>(modelSerializer.logEntrySerializer(), LogEntry.class)));
+        localEndpointField = DSL.field(
+                "localEndpoint",
+                SQLDataType.BINARY.asConvertedDataType(
+                        new JooqConverterAdapter<>(modelSerializer.raftEndpointSerializer(), RaftEndpoint.class)));
+        votedForField = DSL.field(
+                "votedFor",
+                SQLDataType.BINARY.asConvertedDataType(
+                        new JooqConverterAdapter<>(modelSerializer.raftEndpointSerializer(), RaftEndpoint.class)));
+        chunkField = DSL.field(
+                "chunk",
+                SQLDataType.BINARY.asConvertedDataType(
+                        new JooqConverterAdapter<>(modelSerializer.snapshotChunkSerializer(), SnapshotChunk.class)));
+    }
+
+    private void createTablesIfNotExists() {
+        dsl.createTableIfNotExists(KV)
+                .column(KEY)
+                .primaryKey(KEY)
+                .column(localEndpointField)
+                .column(LOCAL_ENDPOINT_VOTING)
+                .column(initialGroupMembersField)
+                .column(TERM)
+                .column(votedForField)
+                .execute();
+        dsl.insertInto(KV).columns(KEY).values(PK).onConflictDoNothing().execute();
+
+        dsl.createTableIfNotExists(LOG_ENTRIES)
+                .column(INDEX)
+                .primaryKey(INDEX)
+                .column(logEntryField)
+                .execute();
+
+        dsl.createTableIfNotExists(SNAPSHOT_CHUNKS)
+                .primaryKey(INDEX, CHUNK_INDEX)
+                .columns(INDEX, CHUNK_INDEX)
+                .column(chunkField)
+                .execute();
+
+        dsl.createTableIfNotExists(SNAPSHOTS)
+                .primaryKey(INDEX, CHUNK_COUNT)
+                .columns(INDEX, CHUNK_COUNT)
+                .execute();
+
+        dsl.connection(Connection::commit);
+    }
+
+    public static RaftSqliteStore create(
+            File sqliteDb, RaftModelFactory raftModelFactory, StoreModelSerializer modelSerializer) {
+        SQLiteConfig config = new SQLiteConfig();
+        config.setPragma(Pragma.JOURNAL_MODE, JournalMode.WAL.getValue());
+        config.setPragma(Pragma.LOCKING_MODE, LockingMode.EXCLUSIVE.getValue());
+        config.setPragma(Pragma.SYNCHRONOUS, "EXTRA");
+
+        CloseableDSLContext dsl = DSL.using(jdbcUrl(sqliteDb), config.toProperties());
+        dsl.connection(conn -> conn.setAutoCommit(false));
+
+        RaftSqliteStore store = new RaftSqliteStore(dsl, modelSerializer, raftModelFactory);
+        store.createTablesIfNotExists();
+        return store;
+    }
+
+    private static String jdbcUrl(File file) {
+        return "jdbc:sqlite:" + file;
+    }
+
+    @Override
+    public void onRaftNodeTerminate() {
+        dsl.connection(Connection::rollback);
+        dsl.close();
+    }
+
+    @Override
+    public void persistAndFlushLocalEndpoint(RaftEndpoint localEndpoint, boolean localEndpointVoting) {
+        dsl.update(KV)
+                .set(localEndpointField, localEndpoint)
+                .set(LOCAL_ENDPOINT_VOTING, localEndpointVoting)
+                .execute();
+        dsl.connection(Connection::commit);
+    }
+
+    @Override
+    public void persistAndFlushInitialGroupMembers(@Nonnull RaftGroupMembersView initialGroupMembers) {
+        dsl.update(KV).set(initialGroupMembersField, initialGroupMembers).execute();
+        dsl.connection(Connection::commit);
+    }
+
+    @Override
+    public void persistAndFlushTerm(int term, @Nullable RaftEndpoint votedFor) {
+        dsl.update(KV).set(TERM, term).set(votedForField, votedFor).execute();
+        dsl.connection(Connection::commit);
+    }
+
+    @Override
+    public void persistLogEntry(@Nonnull LogEntry logEntry) {
+        dsl.insertInto(LOG_ENTRIES, INDEX, logEntryField)
+                .values(logEntry.getIndex(), logEntry)
+                .execute();
+    }
+
+    @Override
+    public void persistSnapshotChunk(@Nonnull SnapshotChunk snapshotChunk) {
+        dsl.insertInto(SNAPSHOT_CHUNKS, INDEX, CHUNK_INDEX, chunkField)
+                .values(snapshotChunk.getIndex(), snapshotChunk.getSnapshotChunkIndex(), snapshotChunk)
+                .execute();
+        dsl.insertInto(SNAPSHOTS, INDEX, CHUNK_COUNT)
+                .values(snapshotChunk.getIndex(), snapshotChunk.getSnapshotChunkCount())
+                .onConflictDoNothing()
+                .execute();
+        tryToCleanUpOldSnapshots = true;
+    }
+
+    // Visible for testing
+    Optional<Long> getMaxCommittedSnapshotIndex() {
+        return Optional.ofNullable(
+                dsl.select(DSL.max(INDEX).as(INDEX)).from(completedSnapshots()).fetchOne(INDEX));
+    }
+
+    private static <T> Field<T> qualify(Table<?> table, Field<T> field) {
+        return DSL.field(DSL.name(table.$name(), field.$name()), field.getType());
+    }
+
+    @Override
+    public void truncateLogEntriesFrom(long logIndexInclusive) {
+        dsl.deleteFrom(LOG_ENTRIES)
+                .where(INDEX.greaterOrEqual(logIndexInclusive))
+                .execute();
+    }
+
+    @SuppressWarnings("VarUsage")
+    private Select<? extends Record1<Long>> completedSnapshots() {
+        Table<?> tempTable = DSL.table("t");
+        var blocks = dsl.select(
+                        qualify(SNAPSHOT_CHUNKS, INDEX),
+                        DSL.count(qualify(SNAPSHOT_CHUNKS, INDEX)).as(COUNT))
+                .from(SNAPSHOT_CHUNKS)
+                .groupBy(qualify(SNAPSHOT_CHUNKS, INDEX));
+        return dsl.select(qualify(tempTable, INDEX))
+                .from(blocks.asTable(tempTable), SNAPSHOTS)
+                .where(qualify(tempTable, INDEX).eq(qualify(SNAPSHOTS, INDEX)))
+                .and(DSL.field(COUNT).eq(CHUNK_COUNT));
+    }
+
+    @Override
+    public void truncateSnapshotChunksUntil(long logIndexInclusive) {
+        dsl.deleteFrom(SNAPSHOT_CHUNKS)
+                .where(qualify(SNAPSHOT_CHUNKS, INDEX).le(logIndexInclusive))
+                .and(qualify(SNAPSHOT_CHUNKS, INDEX).notIn(completedSnapshots()))
+                .execute();
+    }
+
+    // Visible for testing
+    List<SnapshotChunk> getAllSnapshotChunks() {
+        return dsl.select(chunkField)
+                .from(SNAPSHOT_CHUNKS)
+                .orderBy(INDEX, CHUNK_INDEX)
+                .fetch(chunkField);
+    }
+
+    @Override
+    public void flush() {
+        dsl.connection(Connection::commit);
+        if (tryToCleanUpOldSnapshots) {
+            tryToCleanUpOldSnapshots = false;
+            Optional<Long> maybeSnapshotIndex = getMaxCommittedSnapshotIndex();
+            maybeSnapshotIndex.ifPresent(snapshotIndex -> {
+                dsl.deleteFrom(LOG_ENTRIES)
+                        .where(INDEX.lessOrEqual(snapshotIndex))
+                        .execute();
+                dsl.deleteFrom(SNAPSHOT_CHUNKS)
+                        .where(INDEX.lessThan(snapshotIndex))
+                        .execute();
+                dsl.deleteFrom(SNAPSHOTS).where(INDEX.lessThan(snapshotIndex)).execute();
+                dsl.connection(Connection::commit);
+            });
+        }
+    }
+
+    public Optional<RestoredRaftState> getRestoredRaftState() {
+        var record = dsl.select(
+                        localEndpointField, LOCAL_ENDPOINT_VOTING, initialGroupMembersField, TERM, votedForField)
+                .from(KV)
+                .fetchOne();
+
+        if (record == null
+                || record.get(localEndpointField) == null
+                || record.get(LOCAL_ENDPOINT_VOTING) == null
+                || record.get(initialGroupMembersField) == null
+                || record.get(TERM) == null
+                || record.get(votedForField) == null) {
+            return Optional.empty();
+        }
+
+        Optional<SnapshotEntry> snapshot = getMaxCommittedSnapshotIndex().map(lastSnapshotted -> {
+            List<SnapshotChunk> snapshotChunks = dsl.select(chunkField)
+                    .from(SNAPSHOT_CHUNKS)
+                    .where(INDEX.eq(lastSnapshotted))
+                    .orderBy(CHUNK_INDEX)
+                    .fetch(chunkField);
+
+            return raftModelFactory
+                    .createSnapshotEntryBuilder()
+                    .setSnapshotChunks(snapshotChunks)
+                    .setIndex(lastSnapshotted)
+                    .setTerm(snapshotChunks.get(0).getTerm())
+                    .setGroupMembersView(snapshotChunks.get(0).getGroupMembersView())
+                    .build();
+        });
+
+        return Optional.of(new RestoredRaftState(
+                record.get(localEndpointField),
+                record.get(LOCAL_ENDPOINT_VOTING),
+                record.get(initialGroupMembersField),
+                record.get(TERM),
+                record.get(votedForField),
+                snapshot.orElse(null),
+                dsl.select(logEntryField).from(LOG_ENTRIES).orderBy(INDEX).fetch(logEntryField)));
+    }
+
+    private static final class JooqConverterAdapter<T> implements Converter<byte[], T> {
+        private final StoreModelSerializer.Serializer<T> serializer;
+        private final Class<T> clazz;
+
+        private JooqConverterAdapter(StoreModelSerializer.Serializer<T> serializer, Class<T> clazz) {
+            this.serializer = serializer;
+            this.clazz = clazz;
+        }
+
+        @Override
+        @Nullable
+        public T from(@Nullable byte[] bytes) {
+            if (bytes == null) {
+                return null;
+            }
+            return serializer.deserialize(bytes);
+        }
+
+        @Override
+        public byte[] to(T element) {
+            if (element == null) {
+                return null;
+            }
+            return serializer.serialize(element);
+        }
+
+        @Override
+        public Class<byte[]> fromType() {
+            return byte[].class;
+        }
+
+        @Override
+        public Class<T> toType() {
+            return clazz;
+        }
+    }
+}

--- a/microraft-store-sqlite/src/main/java/io/microraft/store/sqlite/StoreModelSerializer.java
+++ b/microraft-store-sqlite/src/main/java/io/microraft/store/sqlite/StoreModelSerializer.java
@@ -1,0 +1,34 @@
+package io.microraft.store.sqlite;
+
+import io.microraft.RaftEndpoint;
+import io.microraft.model.log.LogEntry;
+import io.microraft.model.log.RaftGroupMembersView;
+import io.microraft.model.log.SnapshotChunk;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Similarly to the {@link io.microraft.model.RaftModelFactory}, users of the SQLite implementation must provide
+ * methods for converting a few of their types into binary data for persistence. This logic is expected to be
+ * relatively straightforward for the implementer, since similar logic will exist within the
+ * {@link io.microraft.transport.Transport}. It should be noted that serialization performed here may need to be
+ * deserialized for an indefinite period and so evolution of any relevant types should be considered by the
+ * implementer.
+ */
+public interface StoreModelSerializer {
+    Serializer<RaftGroupMembersView> raftGroupMembersViewSerializer();
+
+    Serializer<RaftEndpoint> raftEndpointSerializer();
+
+    Serializer<LogEntry> logEntrySerializer();
+
+    Serializer<SnapshotChunk> snapshotChunkSerializer();
+
+    interface Serializer<T> {
+        @Nonnull
+        byte[] serialize(@Nonnull T element);
+
+        @Nonnull
+        T deserialize(@Nonnull byte[] element);
+    }
+}

--- a/microraft-store-sqlite/src/main/java/io/microraft/store/sqlite/StoreModelSerializer.java
+++ b/microraft-store-sqlite/src/main/java/io/microraft/store/sqlite/StoreModelSerializer.java
@@ -8,12 +8,14 @@ import io.microraft.model.log.SnapshotChunk;
 import javax.annotation.Nonnull;
 
 /**
- * Similarly to the {@link io.microraft.model.RaftModelFactory}, users of the SQLite implementation must provide
- * methods for converting a few of their types into binary data for persistence. This logic is expected to be
- * relatively straightforward for the implementer, since similar logic will exist within the
- * {@link io.microraft.transport.Transport}. It should be noted that serialization performed here may need to be
- * deserialized for an indefinite period and so evolution of any relevant types should be considered by the
- * implementer.
+ * Similarly to the {@link io.microraft.model.RaftModelFactory}, users of the
+ * SQLite implementation must provide methods for converting a few of their
+ * types into binary data for persistence. This logic is expected to be
+ * relatively straightforward for the implementer, since similar logic will
+ * exist within the {@link io.microraft.transport.Transport}. It should be noted
+ * that serialization performed here may need to be deserialized for an
+ * indefinite period and so evolution of any relevant types should be considered
+ * by the implementer.
  */
 public interface StoreModelSerializer {
     Serializer<RaftGroupMembersView> raftGroupMembersViewSerializer();

--- a/microraft-store-sqlite/src/test/java/io/microraft/store/sqlite/RaftSqliteStoreTest.java
+++ b/microraft-store-sqlite/src/test/java/io/microraft/store/sqlite/RaftSqliteStoreTest.java
@@ -1,0 +1,278 @@
+package io.microraft.store.sqlite;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.microraft.RaftEndpoint;
+import io.microraft.impl.local.LocalRaftEndpoint;
+import io.microraft.model.RaftModelFactory;
+import io.microraft.model.impl.DefaultRaftModelFactory;
+import io.microraft.model.impl.log.DefaultLogEntryOrBuilder;
+import io.microraft.model.impl.log.DefaultRaftGroupMembersViewOrBuilder;
+import io.microraft.model.impl.log.DefaultSnapshotChunkOrBuilder;
+import io.microraft.model.log.LogEntry;
+import io.microraft.model.log.RaftGroupMembersView;
+import io.microraft.model.log.SnapshotChunk;
+import io.microraft.persistence.RestoredRaftState;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RaftSqliteStoreTest {
+    private static final RaftModelFactory raftModelFactory = new DefaultRaftModelFactory();
+
+    private static final RaftEndpoint ENDPOINT_A = LocalRaftEndpoint.newEndpoint();
+    private static final RaftEndpoint ENDPOINT_B = LocalRaftEndpoint.newEndpoint();
+    private static final long RAFT_INDEX = 12345;
+    private static final int TERM = 235;
+    private static final boolean VOTING = true;
+
+    private static final RaftGroupMembersView INITIAL_GROUP_MEMBERS = raftModelFactory
+            .createRaftGroupMembersViewBuilder()
+            .setLogIndex(RAFT_INDEX)
+            .setMembers(List.of(ENDPOINT_A, ENDPOINT_B))
+            .setVotingMembers(List.of(ENDPOINT_A))
+            .build();
+
+    @Rule
+    public final TemporaryFolder tempDir = new TemporaryFolder();
+
+    private File sqlite;
+
+    @Before
+    public void before() throws IOException {
+        sqlite = new File(tempDir.newFolder(), "sqlite.db");
+    }
+
+    private void withRaftStore(Consumer<RaftSqliteStore> consumer) {
+        RaftSqliteStore store = RaftSqliteStore.create(sqlite, raftModelFactory, JacksonModelSerializer.INSTANCE);
+        consumer.accept(store);
+        store.onRaftNodeTerminate();
+    }
+
+    @Test
+    public void noRecoveredStateIfNoWrites() {
+        withRaftStore(store -> assertThat(store.getRestoredRaftState()).isEmpty());
+    }
+
+    @Test
+    public void basicRecoveredState() {
+        withRaftStore(RaftSqliteStoreTest::persistInitialState);
+        withRaftStore(store -> {
+            RestoredRaftState restored = store.getRestoredRaftState().get();
+            assertThat(restored.getLocalEndpoint()).isEqualTo(ENDPOINT_A);
+            assertThat(restored.isLocalEndpointVoting()).isEqualTo(VOTING);
+            assertThat(restored.getInitialGroupMembers())
+                    .usingRecursiveComparison()
+                    .isEqualTo(INITIAL_GROUP_MEMBERS);
+            assertThat(restored.getTerm()).isEqualTo(TERM);
+            assertThat(restored.getVotedMember()).isEqualTo(ENDPOINT_B);
+        });
+    }
+
+    @Test
+    public void testLogEntryFlushing() {
+        withRaftStore(RaftSqliteStoreTest::persistInitialState);
+        withRaftStore(store -> {
+            store.persistLogEntry(logEntry(0, 0));
+            store.persistLogEntry(logEntry(1, 0));
+            store.persistLogEntry(logEntry(2, 0));
+        });
+        withRaftStore(store -> {
+            assertThat(store.getRestoredRaftState().get().getLogEntries()).isEmpty();
+            store.persistLogEntry(logEntry(0, 0));
+            store.persistLogEntry(logEntry(1, 0));
+            store.flush();
+            store.persistLogEntry(logEntry(2, 0));
+        });
+        withRaftStore(store -> {
+            assertThat(store.getRestoredRaftState().get().getLogEntries())
+                    .usingRecursiveFieldByFieldElementComparator()
+                    .containsExactly(logEntry(0, 0), logEntry(1, 0));
+            store.truncateLogEntriesFrom(1);
+            store.flush();
+            assertThat(store.getRestoredRaftState().get().getLogEntries())
+                    .usingRecursiveFieldByFieldElementComparator()
+                    .containsExactly(logEntry(0, 0));
+        });
+    }
+
+    @Test
+    public void testSnapshots() {
+        withRaftStore(store -> {
+            persistInitialState(store);
+            store.persistLogEntry(logEntry(0, 0));
+            store.persistLogEntry(logEntry(1, 0));
+            store.persistLogEntry(logEntry(2, 0));
+            store.flush();
+            store.persistSnapshotChunk(snapshotChunk(1, 0, 0, 1));
+            store.flush();
+            // once a snapshot chunk has been flushed, irrelevant log entries can be deleted
+            assertThat(store.getRestoredRaftState().get().getLogEntries())
+                    .usingRecursiveFieldByFieldElementComparator()
+                    .containsExactly(logEntry(2, 0));
+            assertThat(store.getRestoredRaftState().get().getSnapshotEntry().getOperation())
+                    .usingRecursiveComparison()
+                    .isEqualTo(List.of(snapshotChunk(1, 0, 0, 1)));
+        });
+        withRaftStore(store -> {
+            store.persistLogEntry(logEntry(3, 1));
+            store.flush();
+            store.persistSnapshotChunk(snapshotChunk(3, 1, 1, 2));
+            store.flush();
+            assertThat(store.getRestoredRaftState().get().getLogEntries())
+                    .usingRecursiveFieldByFieldElementComparator()
+                    .contains(logEntry(2, 0), logEntry(3, 1));
+            // snapshots can be committed out of order
+            store.persistSnapshotChunk(snapshotChunk(3, 1, 0, 2));
+            store.flush();
+            // irrelevant snapshot chunks are deleted
+            assertThat(store.getAllSnapshotChunks())
+                    .usingRecursiveFieldByFieldElementComparator()
+                    .containsExactly(snapshotChunk(3, 1, 0, 2), snapshotChunk(3, 1, 1, 2));
+        });
+        withRaftStore(store -> {
+            store.persistSnapshotChunk(snapshotChunk(1, 1, 0, 2));
+            store.persistSnapshotChunk(snapshotChunk(2, 2, 0, 1));
+            store.persistSnapshotChunk(snapshotChunk(4, 1, 0, 2));
+            store.persistSnapshotChunk(snapshotChunk(5, 1, 0, 1));
+            // half persisted snapshots are deleted, but completed snapshots are not
+            store.truncateSnapshotChunksUntil(5);
+            assertThat(store.getAllSnapshotChunks())
+                    .usingRecursiveFieldByFieldElementComparator()
+                    .containsExactly(
+                            snapshotChunk(2, 2, 0, 1),
+                            snapshotChunk(3, 1, 0, 2),
+                            snapshotChunk(3, 1, 1, 2),
+                            snapshotChunk(5, 1, 0, 1));
+        });
+    }
+
+    private static LogEntry logEntry(long index, int term) {
+        return raftModelFactory
+                .createLogEntryBuilder()
+                .setIndex(index)
+                .setTerm(term)
+                .setOperation(index + " " + term)
+                .build();
+    }
+
+    private static SnapshotChunk snapshotChunk(long index, int term, int chunkIndex, int numChunks) {
+        return raftModelFactory
+                .createSnapshotChunkBuilder()
+                .setIndex(index)
+                .setTerm(term)
+                .setSnapshotChunkIndex(chunkIndex)
+                .setSnapshotChunkCount(numChunks)
+                .setGroupMembersView(INITIAL_GROUP_MEMBERS)
+                .setOperation(index + " " + term + " " + chunkIndex + " " + numChunks)
+                .build();
+    }
+
+    private static void persistInitialState(RaftSqliteStore store) {
+        store.persistAndFlushLocalEndpoint(ENDPOINT_A, VOTING);
+        store.persistAndFlushInitialGroupMembers(INITIAL_GROUP_MEMBERS);
+        store.persistAndFlushTerm(TERM, ENDPOINT_B);
+    }
+
+    private enum JacksonModelSerializer implements StoreModelSerializer {
+        INSTANCE;
+
+        @Override
+        public Serializer<RaftGroupMembersView> raftGroupMembersViewSerializer() {
+            return new JacksonSerializer<>(DefaultRaftGroupMembersViewOrBuilder.class);
+        }
+
+        @Override
+        public Serializer<RaftEndpoint> raftEndpointSerializer() {
+            return new JacksonSerializer<>(LocalRaftEndpoint.class);
+        }
+
+        @Override
+        public Serializer<LogEntry> logEntrySerializer() {
+            return new JacksonSerializer<>(DefaultLogEntryOrBuilder.class);
+        }
+
+        @Override
+        public Serializer<SnapshotChunk> snapshotChunkSerializer() {
+            return new JacksonSerializer<>(DefaultSnapshotChunkOrBuilder.class);
+        }
+    }
+
+    /**
+     * Uses the json library Jackson for retrofitting serialization on top of the default model.
+     * If the default model ever gets equals methods, then the recursive comparisons in the tests can be removed.
+     * If the default model ever has a baked in persistence mechanism, then the Jackson can be removed.
+     */
+    private static final class JacksonSerializer<T> implements StoreModelSerializer.Serializer<T> {
+        private static final ObjectMapper objectMapper = new ObjectMapper()
+                .addMixIn(LocalRaftEndpoint.class, RaftEndpointMixin.class)
+                .addMixIn(DefaultRaftGroupMembersViewOrBuilder.class, RaftGroupMembersViewMixin.class)
+                .addMixIn(DefaultLogEntryOrBuilder.class, LogEntryMixin.class)
+                .addMixIn(DefaultSnapshotChunkOrBuilder.class, SnapshotChunkMixin.class);
+
+        private final Class<? extends T> clazz;
+
+        private JacksonSerializer(Class<? extends T> clazz) {
+            this.clazz = clazz;
+        }
+
+        @Nonnull
+        @Override
+        public byte[] serialize(@Nonnull T element) {
+            try {
+                return objectMapper.writeValueAsBytes(element);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Nonnull
+        @Override
+        public T deserialize(@Nonnull byte[] element) {
+            try {
+                return objectMapper.readValue(element, clazz);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static final class RaftEndpointMixin {
+        @JsonValue
+        private String id;
+
+        @JsonCreator
+        private RaftEndpointMixin(String id) {}
+    }
+
+    @JsonDeserialize(builder = DefaultRaftGroupMembersViewOrBuilder.class)
+    private static final class RaftGroupMembersViewMixin {
+
+        @JsonDeserialize(contentAs = LocalRaftEndpoint.class)
+        private Collection<RaftEndpoint> members;
+
+        @JsonDeserialize(contentAs = LocalRaftEndpoint.class)
+        private Collection<RaftEndpoint> votingMembers;
+    }
+
+    @JsonDeserialize(builder = DefaultLogEntryOrBuilder.class)
+    private static final class LogEntryMixin {}
+
+    @JsonDeserialize(builder = DefaultSnapshotChunkOrBuilder.class)
+    private static final class SnapshotChunkMixin {
+        @JsonDeserialize(as = DefaultRaftGroupMembersViewOrBuilder.class)
+        private RaftGroupMembersView groupMembersView;
+    }
+}

--- a/microraft-store-sqlite/src/test/java/io/microraft/store/sqlite/RaftSqliteStoreTest.java
+++ b/microraft-store-sqlite/src/test/java/io/microraft/store/sqlite/RaftSqliteStoreTest.java
@@ -39,11 +39,8 @@ public class RaftSqliteStoreTest {
     private static final boolean VOTING = true;
 
     private static final RaftGroupMembersView INITIAL_GROUP_MEMBERS = raftModelFactory
-            .createRaftGroupMembersViewBuilder()
-            .setLogIndex(RAFT_INDEX)
-            .setMembers(List.of(ENDPOINT_A, ENDPOINT_B))
-            .setVotingMembers(List.of(ENDPOINT_A))
-            .build();
+            .createRaftGroupMembersViewBuilder().setLogIndex(RAFT_INDEX).setMembers(List.of(ENDPOINT_A, ENDPOINT_B))
+            .setVotingMembers(List.of(ENDPOINT_A)).build();
 
     @Rule
     public final TemporaryFolder tempDir = new TemporaryFolder();
@@ -73,9 +70,7 @@ public class RaftSqliteStoreTest {
             RestoredRaftState restored = store.getRestoredRaftState().get();
             assertThat(restored.getLocalEndpoint()).isEqualTo(ENDPOINT_A);
             assertThat(restored.isLocalEndpointVoting()).isEqualTo(VOTING);
-            assertThat(restored.getInitialGroupMembers())
-                    .usingRecursiveComparison()
-                    .isEqualTo(INITIAL_GROUP_MEMBERS);
+            assertThat(restored.getInitialGroupMembers()).usingRecursiveComparison().isEqualTo(INITIAL_GROUP_MEMBERS);
             assertThat(restored.getTerm()).isEqualTo(TERM);
             assertThat(restored.getVotedMember()).isEqualTo(ENDPOINT_B);
         });
@@ -97,13 +92,11 @@ public class RaftSqliteStoreTest {
             store.persistLogEntry(logEntry(2, 0));
         });
         withRaftStore(store -> {
-            assertThat(store.getRestoredRaftState().get().getLogEntries())
-                    .usingRecursiveFieldByFieldElementComparator()
+            assertThat(store.getRestoredRaftState().get().getLogEntries()).usingRecursiveFieldByFieldElementComparator()
                     .containsExactly(logEntry(0, 0), logEntry(1, 0));
             store.truncateLogEntriesFrom(1);
             store.flush();
-            assertThat(store.getRestoredRaftState().get().getLogEntries())
-                    .usingRecursiveFieldByFieldElementComparator()
+            assertThat(store.getRestoredRaftState().get().getLogEntries()).usingRecursiveFieldByFieldElementComparator()
                     .containsExactly(logEntry(0, 0));
         });
     }
@@ -119,11 +112,9 @@ public class RaftSqliteStoreTest {
             store.persistSnapshotChunk(snapshotChunk(1, 0, 0, 1));
             store.flush();
             // once a snapshot chunk has been flushed, irrelevant log entries can be deleted
-            assertThat(store.getRestoredRaftState().get().getLogEntries())
-                    .usingRecursiveFieldByFieldElementComparator()
+            assertThat(store.getRestoredRaftState().get().getLogEntries()).usingRecursiveFieldByFieldElementComparator()
                     .containsExactly(logEntry(2, 0));
-            assertThat(store.getRestoredRaftState().get().getSnapshotEntry().getOperation())
-                    .usingRecursiveComparison()
+            assertThat(store.getRestoredRaftState().get().getSnapshotEntry().getOperation()).usingRecursiveComparison()
                     .isEqualTo(List.of(snapshotChunk(1, 0, 0, 1)));
         });
         withRaftStore(store -> {
@@ -131,15 +122,13 @@ public class RaftSqliteStoreTest {
             store.flush();
             store.persistSnapshotChunk(snapshotChunk(3, 1, 1, 2));
             store.flush();
-            assertThat(store.getRestoredRaftState().get().getLogEntries())
-                    .usingRecursiveFieldByFieldElementComparator()
+            assertThat(store.getRestoredRaftState().get().getLogEntries()).usingRecursiveFieldByFieldElementComparator()
                     .contains(logEntry(2, 0), logEntry(3, 1));
             // snapshots can be committed out of order
             store.persistSnapshotChunk(snapshotChunk(3, 1, 0, 2));
             store.flush();
             // irrelevant snapshot chunks are deleted
-            assertThat(store.getAllSnapshotChunks())
-                    .usingRecursiveFieldByFieldElementComparator()
+            assertThat(store.getAllSnapshotChunks()).usingRecursiveFieldByFieldElementComparator()
                     .containsExactly(snapshotChunk(3, 1, 0, 2), snapshotChunk(3, 1, 1, 2));
         });
         withRaftStore(store -> {
@@ -149,35 +138,22 @@ public class RaftSqliteStoreTest {
             store.persistSnapshotChunk(snapshotChunk(5, 1, 0, 1));
             // half persisted snapshots are deleted, but completed snapshots are not
             store.truncateSnapshotChunksUntil(5);
-            assertThat(store.getAllSnapshotChunks())
-                    .usingRecursiveFieldByFieldElementComparator()
-                    .containsExactly(
-                            snapshotChunk(2, 2, 0, 1),
-                            snapshotChunk(3, 1, 0, 2),
-                            snapshotChunk(3, 1, 1, 2),
-                            snapshotChunk(5, 1, 0, 1));
+            assertThat(store.getAllSnapshotChunks()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+                    snapshotChunk(2, 2, 0, 1), snapshotChunk(3, 1, 0, 2), snapshotChunk(3, 1, 1, 2),
+                    snapshotChunk(5, 1, 0, 1));
         });
     }
 
     private static LogEntry logEntry(long index, int term) {
-        return raftModelFactory
-                .createLogEntryBuilder()
-                .setIndex(index)
-                .setTerm(term)
-                .setOperation(index + " " + term)
+        return raftModelFactory.createLogEntryBuilder().setIndex(index).setTerm(term).setOperation(index + " " + term)
                 .build();
     }
 
     private static SnapshotChunk snapshotChunk(long index, int term, int chunkIndex, int numChunks) {
-        return raftModelFactory
-                .createSnapshotChunkBuilder()
-                .setIndex(index)
-                .setTerm(term)
-                .setSnapshotChunkIndex(chunkIndex)
-                .setSnapshotChunkCount(numChunks)
+        return raftModelFactory.createSnapshotChunkBuilder().setIndex(index).setTerm(term)
+                .setSnapshotChunkIndex(chunkIndex).setSnapshotChunkCount(numChunks)
                 .setGroupMembersView(INITIAL_GROUP_MEMBERS)
-                .setOperation(index + " " + term + " " + chunkIndex + " " + numChunks)
-                .build();
+                .setOperation(index + " " + term + " " + chunkIndex + " " + numChunks).build();
     }
 
     private static void persistInitialState(RaftSqliteStore store) {
@@ -211,9 +187,10 @@ public class RaftSqliteStoreTest {
     }
 
     /**
-     * Uses the json library Jackson for retrofitting serialization on top of the default model.
-     * If the default model ever gets equals methods, then the recursive comparisons in the tests can be removed.
-     * If the default model ever has a baked in persistence mechanism, then the Jackson can be removed.
+     * Uses the json library Jackson for retrofitting serialization on top of the
+     * default model. If the default model ever gets equals methods, then the
+     * recursive comparisons in the tests can be removed. If the default model ever
+     * has a baked in persistence mechanism, then the Jackson can be removed.
      */
     private static final class JacksonSerializer<T> implements StoreModelSerializer.Serializer<T> {
         private static final ObjectMapper objectMapper = new ObjectMapper()
@@ -254,7 +231,8 @@ public class RaftSqliteStoreTest {
         private String id;
 
         @JsonCreator
-        private RaftEndpointMixin(String id) {}
+        private RaftEndpointMixin(String id) {
+        }
     }
 
     @JsonDeserialize(builder = DefaultRaftGroupMembersViewOrBuilder.class)
@@ -268,7 +246,8 @@ public class RaftSqliteStoreTest {
     }
 
     @JsonDeserialize(builder = DefaultLogEntryOrBuilder.class)
-    private static final class LogEntryMixin {}
+    private static final class LogEntryMixin {
+    }
 
     @JsonDeserialize(builder = DefaultSnapshotChunkOrBuilder.class)
     private static final class SnapshotChunkMixin {

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <module>microraft-hocon</module>
         <module>microraft-yaml</module>
         <module>microraft-metrics</module>
+        <module>microraft-store-sqlite</module>
         <module>microraft-tutorial</module>
         <module>afloatdb</module>
     </modules>


### PR DESCRIPTION
This is probably by no means perfect, attempts to mostly be simple. A SQLite implementation of the log to ensure that there's an open-source log that uses persistence.

Adds a concept of a StoreModelSerializer to provide some mechanism of converting the model into bytes to be written on disk.