### PR TITLE
 improve transferLeadership

### DIFF
--- a/microraft/src/main/java/io/microraft/impl/task/TransferLeadershipTask.java
+++ b/microraft/src/main/java/io/microraft/impl/task/TransferLeadershipTask.java
@@ -135,7 +135,8 @@ public class TransferLeadershipTask implements Runnable {
             return;
         }
 
-        if (leaderState.getFollowerState(targetEndpoint).matchIndex() < state.log().lastLogOrSnapshotIndex()) {
+        if (state.commitIndex() < state.log().lastLogOrSnapshotIndex()
+                || leaderState.getFollowerState(targetEndpoint).matchIndex() < state.log().lastLogOrSnapshotIndex()) {
             LOGGER.warn("{} waiting until all appended entries to be committed before transferring leadership to {}",
                     node.localEndpointStr(), targetEndpoint.getId());
             scheduleRetry(state);

--- a/microraft/src/main/java/io/microraft/impl/task/TransferLeadershipTask.java
+++ b/microraft/src/main/java/io/microraft/impl/task/TransferLeadershipTask.java
@@ -135,7 +135,7 @@ public class TransferLeadershipTask implements Runnable {
             return;
         }
 
-        if (state.commitIndex() < state.log().lastLogOrSnapshotIndex()) {
+        if (state.leaderState().getFollowerState(targetEndpoint).matchIndex() < state.log().lastLogOrSnapshotIndex()) {
             LOGGER.warn("{} waiting until all appended entries to be committed before transferring leadership to {}",
                     node.localEndpointStr(), targetEndpoint.getId());
             scheduleRetry(state);

--- a/microraft/src/main/java/io/microraft/impl/task/TransferLeadershipTask.java
+++ b/microraft/src/main/java/io/microraft/impl/task/TransferLeadershipTask.java
@@ -135,7 +135,7 @@ public class TransferLeadershipTask implements Runnable {
             return;
         }
 
-        if (state.leaderState().getFollowerState(targetEndpoint).matchIndex() < state.log().lastLogOrSnapshotIndex()) {
+        if (leaderState.getFollowerState(targetEndpoint).matchIndex() < state.log().lastLogOrSnapshotIndex()) {
             LOGGER.warn("{} waiting until all appended entries to be committed before transferring leadership to {}",
                     node.localEndpointStr(), targetEndpoint.getId());
             scheduleRetry(state);


### PR DESCRIPTION
leader's `commitIndex` not mean the target follower's `commitIndex` , it mean  the majority of  quorum  `commitIndex`. 
 so trigger leader election at this situation may lead to other follower becoming leader.