### PR TITLE
Fixed an issue where the old leader's log could not be synced with the new one due to the absence of a previous LogEntry

### DIFF
--- a/microraft/src/main/java/io/microraft/impl/handler/AppendEntriesRequestHandler.java
+++ b/microraft/src/main/java/io/microraft/impl/handler/AppendEntriesRequestHandler.java
@@ -158,6 +158,8 @@ public class AppendEntriesRequestHandler extends AbstractMessageHandler<AppendEn
             int prevLogTerm;
             if (request.getPreviousLogIndex() == lastLogIndex) {
                 prevLogTerm = lastLogTerm;
+            } else if (log.snapshotIndex() >= request.getPreviousLogIndex()) {
+                prevLogTerm = log.snapshotEntry().getTerm();
             } else {
                 // Reply false if log does not contain an entry at prevLogIndex whose term
                 // matches prevLogTerm (§5.3)


### PR DESCRIPTION
If an old leader's log contains a snapshot and only unreplicated entries, it can't be synchronized with a new leader's log. 

This happens because the new leader can't verify the previous LogEntry of the old leader since this entry is already snapshotted. 

As a fix, we should add a check if `snapshotIndex` is large or equal to `previousLogIndex`, and use the snapshot term in this case.